### PR TITLE
Added setting quicksearch, implemented search options as dialog

### DIFF
--- a/lastship.py
+++ b/lastship.py
@@ -123,7 +123,28 @@ elif action == 'toolNavigator':
     navigator.navigator().tools()
 
 elif action == 'searchNavigator':
-    navigator.navigator().search()
+    if not control.setting('search.quick') == '0':
+        searchSelect = xbmcgui.Dialog().select(control.lang(32010).encode('utf-8'),
+                                               [
+                                                   control.lang(32001).encode('utf-8'),
+                                                   control.lang(32002).encode('utf-8'),
+                                                   control.lang(32029).encode('utf-8'),
+                                                   control.lang(32030).encode('utf-8')
+                                               ])
+        if searchSelect == 0:
+            movies.movies().search()
+            movies.movies().search_new()
+        elif searchSelect == 1:
+            tvshows.tvshows().search()
+            tvshows.tvshows().search_new()
+        elif searchSelect == 2:
+            movies.movies().person()
+        elif searchSelect == 3:
+            tvshows.tvshows().person()
+        else:
+            pass
+    else:
+        navigator.navigator().search()
 
 elif action == 'viewsNavigator':
     navigator.navigator().views()

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -978,3 +978,7 @@ msgstr ""
 msgctxt "#32707"
 msgid "[B]LASTSHIP[/B] : Clear Meta Cache..."
 msgstr ""
+
+msgctxt "#32708"
+msgid "Enable Quick Search"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -983,3 +983,7 @@ msgstr "[B]LASTSHIP[/B] : Lösche alle Speicher"
 msgctxt "#32707"
 msgid "[B]LASTSHIP[/B] : Clear Meta Cache..."
 msgstr "[B]LASTSHIP[/B] : Metadaten Speicher löschen"
+
+msgctxt "#32708"
+msgid "Enable Quick Search"
+msgstr "Schnelle Suche"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,6 +24,7 @@
         <setting id="tv.widget" type="enum" label="32325" lvalues="32302|32326" default="1" visible="eq(-12,)" />
         <setting id="prgr.sortorder" type="enum" label="32584" lvalues="32585|32586" default="1" visible="!eq(-13,)" />
         <setting id="lists.widget" type="enum" label="32329" lvalues="32302|32301" default="1" />
+        <setting id="search.quick" type="enum" label="32708" lvalues="32302|32301" default="0" />
 	<setting type="lsep" label="Trakt Bibliothek - Automatische Synchronisierung" />
         <setting id="autoTraktOnStart" type="bool" label="Synchronisierung bei Kodi Start" default="False" />
         <setting id="schedTraktTime" type="slider" label="Geplante Updates jede - Stunde/n" default="0" range="0,24" option="int" />
@@ -78,7 +79,7 @@
 		<setting id="provider.streamit" type="bool" label="STREAMIT.WS" default="true" />
 		<setting id="provider.tata" type="bool" label="TATA.TO" default="true" />
 	    	<setting id="provider.view4u" type="bool" label="VIEW4U.CO" default="true" />
-		<setting type="sep" />		
+		<setting type="sep" />
 	</category>
     <category label="32346">
         <setting type="lsep" label="FANART.TV" />


### PR DESCRIPTION
Wenn man in den Settings nun "Schnelle Suche" aktiviert und im Menü auf "Suche" drückt, werden die Unterscheidungen "Film/Serie/Person" als Overlay angezeigt. Geht dadurch schneller.

<details><summary>PoC Gif</summary> 
<img src="https://media.giphy.com/media/cAlCUeJGFVMpEP7NrS/giphy.gif" width="500" height="300" />
</details>

